### PR TITLE
Added jail data persistance and other fixes

### DIFF
--- a/atlas-duty/__server.lua
+++ b/atlas-duty/__server.lua
@@ -84,7 +84,7 @@ local function CheckCooldown(source)
 end
 
 RegisterCommand("clockin", function(source, args, rawCommand)
-    if exports['EasyAdmin']:IsPlayerAdmin(source) then
+    if exports['EasyAdmin-ox']:IsPlayerAdmin(source) then
         if HasDutyBypass(source) then
             TriggerClientEvent('ox_lib:notify', source, {
                 title = 'Staff Clock In',
@@ -113,7 +113,7 @@ RegisterCommand("clockin", function(source, args, rawCommand)
 end, false)
 
 RegisterCommand("clockout", function(source, args, rawCommand)
-    if exports['EasyAdmin']:IsPlayerAdmin(source) then
+    if exports['EasyAdmin-ox']:IsPlayerAdmin(source) then
         if HasDutyBypass(source) then
             Player(source).state['atlasstaff:clockedIn'] = 'no'
             TriggerClientEvent('ox_lib:notify', source, {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,6 +11,11 @@ lua54 'yes'
 
 rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'
 
+dependencies {
+    'ox_lib',
+    'yarn'
+}
+
 shared_scripts {
     'shared/util_shared.lua',
     '@ox_lib/init.lua',
@@ -42,10 +47,6 @@ ui_page "dependencies/nui/index.html"
 files {
     "dependencies/images/*.png",
     "dependencies/nui/**/*"
-}
-
-dependencies {
-    'yarn'
 }
 
 provide 'EasyAdmin'

--- a/liam-jail/client.lua
+++ b/liam-jail/client.lua
@@ -42,18 +42,20 @@ AddEventHandler("Liam:JailPlayer", function(jailtime, reason)
                 
                 if distance > MaxDistance then
                     SetEntityCoords(playerPed, JailCoords)
-                    jailtime = jailtime + TimeAddedForEscape
-                    if jailtime > 1500 then
-                        jailtime = 1500
-                    end
+                    -- jailtime = jailtime + TimeAddedForEscape
+                    -- if jailtime > 1500 then
+                    --     jailtime = 1500
+                    -- end
                     lib.notify({
                         title = 'Escape Attempt',
-                        description = "Your jail time was extended by " .. TimeAddedForEscape .. " seconds because you tried to escape.",
+                        -- description = "Your jail time was extended by " .. TimeAddedForEscape .. " seconds because you tried to escape.",
+                        description = "Your escape attempt failed miserably.",
                         type = 'error'
                     })
                 end
-                
-                jailtime = jailtime - 0.5
+                  jailtime = jailtime - 0.5
+                -- Update server with remaining time
+                TriggerServerEvent("Liam:UpdateJailTime", jailtime)
             end
             
             lib.hideTextUI()

--- a/liam-jail/server.lua
+++ b/liam-jail/server.lua
@@ -1,8 +1,81 @@
--- Jail event handler
+-- File operations for jail data
+local jailDataPath = GetResourcePath(GetCurrentResourceName())..'/jail_data.json'
+
+local function LoadJailData()
+    local file = io.open(jailDataPath, 'r')
+    if file then
+        local content = file:read('*all')
+        file:close()
+        return json.decode(content) or {}
+    end
+    return {}
+end
+
+local function SaveJailData(data)
+    local file = io.open(jailDataPath, 'w')
+    if file then
+        file:write(json.encode(data))
+        file:close()
+    end
+end
+
+local function GetFivemIdentifier(player)
+    local identifiers = GetPlayerIdentifiers(player)
+    for _, v in pairs(identifiers) do
+        if string.find(v, "fivem") then
+            return v
+        end
+    end
+    return nil
+end
+
+
+local jailData = LoadJailData()
+
+-- Event for player connecting
+AddEventHandler('playerConnecting', function(name, setKickReason, deferrals)
+    local source = source
+    local identifier = GetFivemIdentifier(source)
+    if identifier and jailData[identifier] then
+        local jailInfo = jailData[identifier]
+        if jailInfo.remainingTime > 0 then
+            -- Player still has time to serve, resume their jail time
+            Citizen.CreateThread(function()
+                Citizen.Wait(2000) -- Wait for player to fully connect
+                TriggerClientEvent("Liam:JailPlayer", source, jailInfo.remainingTime, jailInfo.reason)
+            end)
+        else
+            -- Remove from jail data if time served
+            jailData[identifier] = nil
+            SaveJailData(jailData)
+        end
+    end
+end)
+
+-- Event for player disconnecting
+AddEventHandler('playerDropped', function(reason)
+    local source = source    
+    local identifier = GetFivemIdentifier(source)
+    
+    if identifier and jailData[identifier] and jailData[identifier].remainingTime > 0 then
+        SaveJailData(jailData)
+    end
+end)
+
+-- Original Jail event handler with persistence
 RegisterNetEvent("Liam:JailPlayerServer")
 AddEventHandler("Liam:JailPlayerServer", function(targetId, jailtime, jailReason)
     local targetPlayer = tonumber(targetId)
     if targetPlayer and GetPlayerName(targetPlayer) then
+        local identifier = GetFivemIdentifier(targetPlayer)
+        if identifier then
+            jailData[identifier] = {
+                remainingTime = jailtime,
+                reason = jailReason
+            }
+            SaveJailData(jailData)
+        end
+        
         local playerName = GetPlayerName(targetPlayer)
         local playerIdentifiers = GetPlayerIdentifiers(targetPlayer)
         local discordId = nil
@@ -33,11 +106,27 @@ AddEventHandler("Liam:JailPlayerServer", function(targetId, jailtime, jailReason
     end
 end)
 
--- Unjail event handler
+-- Updated Unjail event handler
 RegisterNetEvent("Liam:UnjailPlayerServer")
 AddEventHandler("Liam:UnjailPlayerServer", function(targetId)
     local targetPlayer = tonumber(targetId)
     if targetPlayer and GetPlayerName(targetPlayer) then
+        local identifier = GetFivemIdentifier(targetPlayer)
+        if identifier and jailData[identifier] then
+            jailData[identifier] = nil
+            SaveJailData(jailData)
+        end
         TriggerClientEvent("Liam:UnjailPlayer", targetPlayer)
+    end
+end)
+
+-- New event to update remaining time
+RegisterNetEvent("Liam:UpdateJailTime")
+AddEventHandler("Liam:UpdateJailTime", function(remainingTime)
+    local source = source
+    local identifier = GetFivemIdentifier(source)
+    if identifier and jailData[identifier] then
+        jailData[identifier].remainingTime = remainingTime
+        SaveJailData(jailData)
     end
 end)


### PR DESCRIPTION
Implemented jail time persistence: players who disconnect and reconnect will now resume serving any remaining jail time, ensuring sentences are fully served.

Fixed incorrect _atlas-duty_ export names — updated to use the correct resource name **EasyAdmin-ox** instead of **EasyAdmin**.

Commented out the sentence extension for escape attempts, as it’s not relevant or necessary in the context of a staff jail. (it also unintentionally added time to sentences upon rejoining as the player would be over the distance threshold. This could easily be solved with a grace period however)